### PR TITLE
Update CI/CD Configuration for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: GitHub Action CI
+
+on: workflow_dispatch
+
+env:
+  IMAGE_NAME: 82240947
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Repository checkout
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.REPO_TOKEN }}
+
+    # JDK 설치
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+
+    # Spring Boot 애플리케이션 패키징
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Kustomize 설치
+    - name: Setup Kustomize
+      uses: imranismail/setup-kustomize@v1
+
+    # 버전 생성
+    - name: 'Gen Version'
+      id: gen-version
+      run: |
+        echo "::set-output name=VERSION::$(date +%Y%m%d%H%M)"
+
+    # ACR 로그인
+    - name: 'ACR login'
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.BASEACR_LOGIN_SERVER }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    # Docker 이미지 빌드 및 태깅
+    - name: 'Build & Tag Image'
+      run: |
+        docker build -t ${{ secrets.BASEACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }} -f Dockerfile .
+        docker tag ${{ secrets.BASEACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }} ${{ secrets.STAPACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }}
+
+    # 배포 ACR에 이미지 푸시
+    - name: 'Push image'
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.STAPACR_LOGIN_SERVER }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+    
+    - run: |
+        docker push ${{ secrets.STAPACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }}
+    
+    # Kustomize를 사용하여 manifests에 이미지 태그 변경
+    - name: Update Kubernetes resources
+      run: |
+        cd manifests/overlays/prod
+        kustomize edit set image ${{ secrets.STAPACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }}
+        cat kustomization.yaml
+
+    # 변경 사항 커밋 및 푸시
+    - name: Commit files
+      run: |
+        cd manifests
+        git config --global user.email "github-actions@github.com"
+        git config --global user.name "github-actions"
+        git commit -am "Update image tag"
+        git push origin main
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM cepgbaseacr.azurecr.io/docker.io/openjdk:17-slim
+VOLUME /tmp
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app.jar"]
+

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "82240947"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: 82240947
+  template:
+    metadata:
+      labels:
+        app: 82240947
+    spec:
+      containers:
+        - name: "82240947"
+          image: cepgbaseacr.azurecr.io/82240947
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-db-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-db-secret
+                  key: password
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/overlays/prod
+      volumes:
+        - name: config-volume
+          configMap:
+            name: 82240947-configmap

--- a/manifests/base/ingress.yaml
+++ b/manifests/base/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "82240947-ingress"
+spec:
+  ingressClassName: ingress-internal
+  rules:
+  - host: yrapp-82240947.cepg-aa.kubepia.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: my-82240947
+            port:
+              number: 8080

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deployment.yaml
+- service.yaml
+- ingress.yaml

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-82240947
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: 82240947
+  type: ClusterIP

--- a/manifests/overlays/prod/application.yml
+++ b/manifests/overlays/prod/application.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://ce-aa-psql.postgres.database.azure.com:5432/postgres
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    defer-datasource-initialization: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+  sql:
+    init:
+      mode: embedded
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+pvc:
+  path: /mnt/cloud-sample

--- a/manifests/overlays/prod/configmap.yaml
+++ b/manifests/overlays/prod/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: 82240947-configmap
+data:
+  application.yml: |
+    spring:
+      datasource:
+        driver-class-name: org.postgresql.Driver
+        url: jdbc:postgresql://cepg-aa-std-db.postgres.database.azure.com:5432/postgres
+        username: ${DB_USERNAME}
+        password: ${DB_PASSWORD}
+        hikari:
+          maximum-pool-size: 2
+          minimum-idle: 2
+      jpa:
+        show-sql: true
+        hibernate:
+          ddl-auto: update
+        defer-datasource-initialization: true
+        properties:
+          hibernate:
+            dialect: org.hibernate.dialect.PostgreSQLDialect
+            format_sql: true
+    server:
+      port: 8080
+

--- a/manifests/overlays/prod/deployment.yaml
+++ b/manifests/overlays/prod/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "82240947"
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: "82240947"
+          command: ["java","-jar","/app.jar"]
+          args: ["--spring.config.location=file:/config/application.yml"]
+          volumeMounts:
+            - mountPath: /mnt/cloud-sample
+              name: "82240947-volume"
+              readOnly: false
+              subPath: cloud-sample
+            - mountPath: /config
+              name: application-properties
+              readOnly: true
+      volumes:
+        - name: "82240947-volume"
+          persistentVolumeClaim:
+            claimName: cepg-aa-std-pvc
+        - name: application-properties
+          configMap:
+            name: "82240947-configmap"
+            items:
+              - key: application.yml
+                path: application.yml
+            defaultMode: 420
+

--- a/manifests/overlays/prod/ingress.yaml
+++ b/manifests/overlays/prod/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "82240947-ingress"
+spec:
+  ingressClassName: ingress-internal
+  rules:
+  - host: yrapp-82240947.cepg-aa.kubepia.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: my-82240947
+            port:
+              number: 8080

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -1,0 +1,17 @@
+configMapGenerator:
+- files:
+  - application.yml
+  name: "82240947-configmap"
+resources:
+- ../../base
+- pvc.yaml
+patchesStrategicMerge:
+- deployment.yaml
+- ingress.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: prod-
+images:
+- name: cepgstapacr.azurecr.io/82240947
+  newTag: "20241028"
+

--- a/manifests/overlays/prod/pvc.yaml
+++ b/manifests/overlays/prod/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cepg-aa-std-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: cepg-aa-std-rwmany
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/pom_bak.xml
+++ b/pom_bak.xml
@@ -11,7 +11,7 @@
 	<groupId>com.example</groupId>
 	<artifactId>template</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>82240947</name>
+	<name>template</name>
 	<description>Demo project for Spring Boot</description>
 	<url/>
 	<licenses>
@@ -29,19 +29,6 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<repositories>
-		<repository>
-		<id>github</id>
-		<url>https://maven.pkg.github.com/leeyiryeong/82240947</url>
-		</repository>
-	</repositories>
-	<distributionManagement>
-		<repository>
-		<id>github</id>
-		<name>GitHub leeyiryeong Apache Maven Packages</name>
-		<url>https://maven.pkg.github.com/leeyiryeong/82240947</url>
-		</repository>
-	</distributionManagement>
 
 	<dependencies>
 	    <dependency>

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,0 +1,16 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    @GetMapping
+    public String getUser() {
+        String userId = "sampleapp1-82240947";
+        return userId;
+    }
+}


### PR DESCRIPTION
- GitHub Actions를 사용하여 CI/CD 파이프라인을 설정
- Docker 이미지 빌드 및 태깅을 자동화
- Kubernetes 배포를 위한 kustomize 설정을 포함
- 데이터베이스 비밀번호를 시크릿으로 관리
- 추가적인 설정 및 변경 사항을 적용

이 변경 사항이 `main` 브랜치에 병합되면 자동 배포가 가능
