### PR TITLE
Fix Deployment Configuration Due to Previous deploy Issues

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: 82240947
+      app: "82240947"
   template:
     metadata:
       labels:
-        app: 82240947
+        app: "82240947"
     spec:
       containers:
         - name: "82240947"

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -7,5 +7,5 @@ spec:
     - port: 8080
       targetPort: 8080
   selector:
-    app: 82240947
+    app: "82240947"
   type: ClusterIP


### PR DESCRIPTION
1. 선택자와 레이블을 적절하게 처리하도록 배포 YAML 파일을 수정
2. 유형 불일치와 관련된 오류를 피하기 위해 서비스 구성을 조정