### PR TITLE
Update Ingress Host to Reflect User ID API

### DIFF
--- a/manifests/base/ingress.yaml
+++ b/manifests/base/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: ingress-internal
   rules:
-  - host: yrapp-82240947.cepg-aa.kubepia.net
+  - host: sampleapp1-82240947.cepg-aa.kubepia.net
     http:
       paths:
       - path: /

--- a/manifests/overlays/prod/ingress.yaml
+++ b/manifests/overlays/prod/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: ingress-internal
   rules:
-  - host: yrapp-82240947.cepg-aa.kubepia.net
+  - host: sampleapp1-82240947.cepg-aa.kubepia.net
     http:
       paths:
       - path: /


### PR DESCRIPTION
1. Ingress 호스트를 요구되는 형식인 [user_id].ce-aa.kubepia.net으로 수정
2. 사용자 ID를 가져오는 API 경로가 올바르게 처리