### PR TITLE
Changed the image tag to use 'latest' as the default tag

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: "82240947"
-          image: cepgbaseacr.azurecr.io/82240947:202410280940
+          image: cepgbaseacr.azurecr.io/82240947:latest
           ports:
             - containerPort: 8080
           env:

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 namePrefix: prod-
 images:
   - name: cepgstapacr.azurecr.io/82240947
-    newTag: "202410280940"
+    newTag: "latest`"


### PR DESCRIPTION
파일에서 이미지 태그를 기본 태그로 'latest'로 변경합니다.
 이 변경은 가장 최신 버전의 이미지가 배포되도록 하여 업데이트를 용이하게 하고 환경 간의 일관성을 유지하도록 재변경.
