### PR TITLE
Add ACR Secret creation script

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: "82240947"
     spec:
+      imagePullSecrets:
+        - name: acr-secret
       containers:
         - name: "82240947"
           image: cepgbaseacr.azurecr.io/82240947:latest
@@ -35,3 +37,4 @@ spec:
         - name: config-volume
           configMap:
             name: 82240947-configmap
+


### PR DESCRIPTION
Azure Container Registry(ACR)에서 이미지를 안전하게 가져오기 위한 비밀을 생성하는 스크립트를 추가

#### 변경 사항:
- ACR에 접근하기 위한 Docker 레지스트리 비밀 생성 명령을 추가
- 비밀의 구성 요소는 다음과 같습니다:
  - **Docker 서버**: ACR 주소
  - **사용자 이름**: ACR 서비스 주체의 클라이언트 ID
  - **비밀번호**: ACR 서비스 주체의 클라이언트 비밀
  - **이메일**: ACR에 대한 인증을 위한 이메일 주소

이 스크립트를 통해 ACR에 대한 인증을 간편하게 설정
,CI/CD 파이프라인에서 이미지 배포 시 필요한 인증 정보를 자동으로 처리할 수 있습니다.

#### 관련 이슈:
- ACR 인증 문제 해결
- CI/CD 개선