### PR TITLE
Update GitHub Actions CI/CD workflow to use Service Principal for ACR authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "::set-output name=VERSION::$(date +%Y%m%d%H%M)"
 
-    # ACR 로그인
+    # Base ACR 로그인
     - name: 'ACR login'
       uses: azure/docker-login@v1
       with:
@@ -51,17 +51,17 @@ jobs:
         docker build -t ${{ secrets.BASEACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }} -f Dockerfile .
         docker tag ${{ secrets.BASEACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }} ${{ secrets.STAPACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }}
 
-    # 배포 ACR에 이미지 푸시
+    # CI/CD ACR에 로그인 및 이미지 푸시
     - name: 'Push image'
       uses: azure/docker-login@v1
       with:
         login-server: ${{ secrets.STAPACR_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        username: ${{ secrets.CI_ACR_USERNAME }}
+        password: ${{ secrets.CI_ACR_PASSWORD }}
     
     - run: |
         docker push ${{ secrets.STAPACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ steps.gen-version.outputs.VERSION }}
-    
+
     # Kustomize를 사용하여 manifests에 이미지 태그 변경
     - name: Update Kubernetes resources
       run: |

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         - name: acr-secret
       containers:
         - name: "82240947"
-          image: cepgbaseacr.azurecr.io/82240947:latest
+          image: cepgbaseacr.azurecr.io/82240947
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
1. ACR 로그인용 CI_ACR_USERNAME 및 CI_ACR_PASSWORD 비밀 추가
2. 이미지를 CI/CD ACR에 푸시하도록 워크플로 수정
3. Kubernetes 매니페스트에서 이미지 태깅이 올바르게 되도록 확인