### PR TITLE
Add ACR login step before pushing image to STAPACR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,15 @@ jobs:
           docker build -t cepgbaseacr.azurecr.io/${{ env.IMAGE_NAME }}:latest -f Dockerfile .
           docker tag cepgbaseacr.azurecr.io/${{ env.IMAGE_NAME }}:latest ${{ secrets.STAPACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:latest
 
+      # STAPACR에 로그인
+      - name: 'STAPACR login'
+        run: |
+          echo ${{ secrets.CI_ACR_PASSWORD }} | docker login ${{ secrets.STAPACR_LOGIN_SERVER }} --username ${{ secrets.CI_ACR_USERNAME }} --password-stdin
+
       # CI/CD ACR에 이미지 푸시
       - name: 'Push image'
         run: |
-          docker push cepgbaseacr.azurecr.io/${{ env.IMAGE_NAME }}:latest
+          docker push ${{ secrets.STAPACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:latest
 
       # AKS 클러스터에 대한 자격 증명 가져오기
       - name: Get AKS credentials
@@ -54,3 +59,4 @@ jobs:
       - name: Deploy to AKS
         run: |
           kubectl apply -f manifests/overlays/prod  # Kustomize를 사용하여 배포
+


### PR DESCRIPTION
Add ACR login step before pushing image to STAPACR

- Implemented login to STAPACR using CI_ACR_USERNAME and CI_ACR_PASSWORD
- Ensured Docker image is pushed to the correct ACR after successful login