### PR TITLE
fix: Add imagePullSecrets to Deployment for ACR acces

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         app: "82240947"
     spec:
+      imagePullSecrets:
+        - name: image-pull-secret
       containers:
         - name: "82240947"
-          image: ceappacr.azurecr.io/82240947
+          image: ceappacr.azurecr.io/82240947:latest
           ports:
             - containerPort: 8080
           volumeMounts:
@@ -24,3 +26,4 @@ spec:
         - name: config-volume
           configMap:
             name: 82240947-configmap
+

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -19,4 +19,3 @@ patchesStrategicMerge:
 images:
 - name: ceappacr.azurecr.io/82240947
   newTag: "202410290000"
-


### PR DESCRIPTION
- Updated the Deployment manifest to include imagePullSecrets for pulling images from Azure Container Registry.
- Ensured that the imagePullSecret is set to "image-pull-secret" to facilitate authentication.